### PR TITLE
Fix memory corruption that can occur during a Ruby GC run.

### DIFF
--- a/ext/libarchive-ruby-swig/entry.h
+++ b/ext/libarchive-ruby-swig/entry.h
@@ -284,7 +284,7 @@ class Entry
         static VALUE c_archive = rb_define_module("Archive");
         static VALUE e_archive =
             rb_define_class_under(c_archive, "Error", rb_eStandardError);
-        static VALUE o_except = rb_exc_new2(e_archive, err.what());
+        VALUE o_except = rb_exc_new2(e_archive, err.what());
         rb_exc_raise(o_except);
     }
 }

--- a/ext/libarchive-ruby-swig/reader.h
+++ b/ext/libarchive-ruby-swig/reader.h
@@ -37,7 +37,7 @@ class Reader
         static VALUE c_archive = rb_define_module("Archive");
         static VALUE e_archive =
             rb_define_class_under(c_archive, "Error", rb_eStandardError);
-        static VALUE o_except = rb_exc_new2(e_archive, err.what());
+        VALUE o_except = rb_exc_new2(e_archive, err.what());
         rb_exc_raise(o_except);
     }
 }

--- a/ext/libarchive-ruby-swig/writer.h
+++ b/ext/libarchive-ruby-swig/writer.h
@@ -68,7 +68,7 @@ class Writer
         static VALUE c_archive = rb_define_module("Archive");
         static VALUE e_archive =
             rb_define_class_under(c_archive, "Error", rb_eStandardError);
-        static VALUE o_except = rb_exc_new2(e_archive, err.what());
+        VALUE o_except = rb_exc_new2(e_archive, err.what());
         rb_exc_raise(o_except);
     }
 }


### PR DESCRIPTION
It's kind of a long story, but the short version is that using the static qualifier for o_except can lead to memory corruption during a Ruby GC run. This change fixes that.
