### PR TITLE
Fix types for read_data_helper

### DIFF
--- a/ext/libarchive-ruby-swig/reader.cpp
+++ b/ext/libarchive-ruby-swig/reader.cpp
@@ -149,8 +149,7 @@ Entry *Reader::next_header()
     return result;
 }
 
-
-VALUE Reader::read_data_helper(int len)
+VALUE Reader::read_data_helper(size_t len)
 {
     std::string error_msg = "error while reading from archive";
 

--- a/ext/libarchive-ruby-swig/reader.h
+++ b/ext/libarchive-ruby-swig/reader.h
@@ -55,7 +55,7 @@ class Reader
             const char *cmd = 0, bool raw = false);
 
         Entry *next_header();
-        VALUE read_data_helper(int len);
+        VALUE read_data_helper(size_t len);
 
 #ifdef SWIG
 %exception;
@@ -64,7 +64,7 @@ class Reader
     private:
         struct archive *_ar;
         char *_buf;
-        int _buf_size;
+        size_t _buf_size;
         char *_archive_content;
 };
 


### PR DESCRIPTION
Fix some `int` types in Reader which should be `size_t`
